### PR TITLE
feat: Add LeakyReLU activation function

### DIFF
--- a/activation.go
+++ b/activation.go
@@ -148,7 +148,7 @@ func (a LeakyReLU) Df(y float64, eps ...float64) (float64, error) {
 	}
 	
 	if y > 0 {
-		return 1
+		return 1, nil
 	}
 	return epsilon, nil
 }


### PR DESCRIPTION
I added another activation function, i.e. LeakyReLU. This can be increase numerical efficiency in cases where you have flat cost functions.

Another implementation choice could be add another parameter to ReLU, whose default is 0 and then just use that with other values also for LeakyReLU.