### PR TITLE
fix: f.Close() should after error handle

### DIFF
--- a/examples/wines/wines.go
+++ b/examples/wines/wines.go
@@ -49,10 +49,10 @@ func main() {
 
 func load(path string) (training.Examples, error) {
 	f, err := os.Open(path)
-	defer f.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 	r := csv.NewReader(bufio.NewReader(f))
 
 	var examples training.Examples


### PR DESCRIPTION
File Close should after error handle