### PR TITLE
remove redundant copy

### DIFF
--- a/training/trainer.go
+++ b/training/trainer.go
@@ -46,9 +46,6 @@ func newTraining(layers []*deep.Layer) *internal {
 func (t *OnlineTrainer) Train(n *deep.Neural, examples, validation Examples, iterations int) {
 	t.internal = newTraining(n.Layers)
 
-	train := make(Examples, len(examples))
-	copy(train, examples)
-
 	t.printer.Init(n)
 	t.solver.Init(n.NumWeights())
 


### PR DESCRIPTION
Within the train func, a variable `train` was created but not used. This PR is just removing the redundant variable and the accompanying `copy` command.