### PR TITLE
update to fix data race

### DIFF
--- a/training/model.go
+++ b/training/model.go
@@ -1,6 +1,9 @@
 package training
 
-import "math/rand"
+import (
+	"math/rand"
+	"sync"
+)
 
 // Example is an input-target pair
 type Example struct {
@@ -8,14 +11,18 @@ type Example struct {
 	Response []float64
 }
 
+var mu sync.Mutex
+
 // Examples is a set of input-output pairs
 type Examples []Example
 
 // Shuffle shuffles slice in-place
 func (e Examples) Shuffle() {
 	for i := range e {
+		mu.Lock()
 		j := rand.Intn(i + 1)
 		e[i], e[j] = e[j], e[i]
+		mu.Unlock()
 	}
 }
 


### PR DESCRIPTION
For now, the `Shuffle()` function in training/model.go is:
```Go
func (e Examples) Shuffle() {
	for i := range e {
		j := rand.Intn(i + 1)
		e[i], e[j] = e[j], e[i]
	}
}
```
which uses the `rand.Intn` and performs write in a concurrent way. When the `Shuffle()` function is called in a concurrent way, there will be race condition error:
```
WARNING: DATA RACE
Read at 0x00c0001280c0 by goroutine 25:
  github.com/patrikeh/go-deep/training.Examples.Shuffle()
      /Users/xxx/go/pkg/mod/github.com/patrikeh/go-deep@v0.0.0-20230427173908-a2775168ab3d/training/model.go:18 +0xd5
  github.com/patrikeh/go-deep/training.(*OnlineTrainer).Train()
      /Users/xxx/go/pkg/mod/github.com/patrikeh/go-deep@v0.0.0-20230427173908-a2775168ab3d/training/trainer.go:54 +0x40d
  test.BenchmarkShuffle.func3()
      /Users/xxx/Desktop/Train.go:51 +0xba

Previous write at 0x00c0001280c0 by goroutine 24:
  github.com/patrikeh/go-deep/training.Examples.Shuffle()
      /Users/xxx/go/pkg/mod/github.com/patrikeh/go-deep@v0.0.0-20230427173908-a2775168ab3d/training/model.go:18 +0x1b9
  github.com/patrikeh/go-deep/training.(*OnlineTrainer).Train()
      /Users/xxx/go/pkg/mod/github.com/patrikeh/go-deep@v0.0.0-20230427173908-a2775168ab3d/training/trainer.go:54 +0x40d
  test.BenchmarkShuffle.func2()
      /Users/xxx/Desktop/Train.go:50 +0xba
```
I suggest we should add a mutex lock to the function, as this PR does.